### PR TITLE
Don't add Skip and Capture automatically in Engine.

### DIFF
--- a/.swiftpm/xcode/xcshareddata/xcschemes/Patterns.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/Patterns.xcscheme
@@ -38,11 +38,6 @@
                BlueprintName = "PatternsTests"
                ReferencedContainer = "container:">
             </BuildableReference>
-            <SkippedTests>
-               <Test
-                  Identifier = "PatternsTests/testSkipWithRepeatingPattern()">
-               </Test>
-            </SkippedTests>
          </TestableReference>
       </Testables>
    </TestAction>

--- a/Sources/Patterns/Decoder.swift
+++ b/Sources/Patterns/Decoder.swift
@@ -35,7 +35,7 @@ extension Parser.Match where Input == String {
 				}
 			} ?? match.captures
 
-			self.match = Parser.Match(fullRange: match.fullRange, captures: captures)
+			self.match = Parser.Match(endIndex: match.endIndex, captures: captures)
 			self.string = string
 			self.codingPath = codingPath
 		}
@@ -53,7 +53,7 @@ extension Parser.Match where Input == String {
 				throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: codingPath, debugDescription:
 					"Property '\(codingPath.map { "\($0.stringValue)" }.joined(separator: "."))' needs a single value, but multiple captures exists."))
 			}
-			let range = match.captures.first?.range ?? match.fullRange
+			let range = match.captures.first?.range ?? match.endIndex ..< match.endIndex
 			return StringDecoder(string: String(string[range]), codingPath: codingPath)
 		}
 

--- a/Sources/Patterns/Operations on Patterns/Concatenation.swift
+++ b/Sources/Patterns/Operations on Patterns/Concatenation.swift
@@ -21,10 +21,25 @@ public struct ConcatenationPattern<Left: Pattern, Right: Pattern>: Pattern {
 		self.left = left
 		self.right = right
 	}
+}
 
+extension ConcatenationPattern where Left == Skip<AnyPattern> {
+	// Is never called. Don't know why.
 	public func createInstructions(_ instructions: inout Instructions) {
-		left.createInstructions(&instructions)
-		right.createInstructions(&instructions)
+		let rightInstructions = right.createInstructions()
+		instructions.append(contentsOf: left.prependSkip(rightInstructions))
+	}
+}
+
+extension ConcatenationPattern {
+	public func createInstructions(_ instructions: inout Instructions) {
+		if let skip = left as? Skip<AnyPattern> {
+			let rightInstructions = right.createInstructions()
+			instructions.append(contentsOf: skip.prependSkip(rightInstructions))
+		} else {
+			left.createInstructions(&instructions)
+			right.createInstructions(&instructions)
+		}
 	}
 }
 

--- a/Sources/Patterns/Operations on Patterns/Skip.swift
+++ b/Sources/Patterns/Operations on Patterns/Skip.swift
@@ -85,8 +85,11 @@ public struct Skip<Repeated: Pattern>: Pattern {
 			let skipInstructions = (repeatedPattern.repeat(0...).createInstructions() + [.match])[...]
 			searchInstruction = .function { (input, thread) -> Bool in
 				guard let end = search(input, thread.inputIndex) else { return false }
-				guard let newThread = VMBacktrackEngine<Input>.backtrackingVM(skipInstructions, input: String(input.prefix(upTo: end)),
-				                                                              thread: Thread(startAt: skipInstructions.startIndex, withDataFrom: thread)),
+				guard
+					let newThread = VMBacktrackEngine<Input>.backtrackingVM(
+						skipInstructions,
+						input: String(input.prefix(upTo: end)),
+						thread: Thread(startAt: skipInstructions.startIndex, withDataFrom: thread)),
 					newThread.inputIndex == end else { return false }
 
 				thread = Thread(startAt: thread.instructionIndex + 1, withDataFrom: newThread)
@@ -103,9 +106,9 @@ public struct Skip<Repeated: Pattern>: Pattern {
 			$0 += .moveIndex(offset: -chars.count)
 			$0 += nonIndexMovers
 			$0 += remainingInstructions
-			if self.repeatedPattern != nil {
+	//		if self.repeatedPattern != nil {
 				$0 += .cancelLastSplit
-			}
+	//		}
 		}
 	}
 }
@@ -123,3 +126,4 @@ extension Skip where Repeated == Literal {
 		self.description = "Skip(\(repeatedPattern))"
 	}
 }
+

--- a/Sources/unicode_properties/main.swift
+++ b/Sources/unicode_properties/main.swift
@@ -9,7 +9,7 @@ func unicodeProperty(fromDataFile text: String) -> [(range: ClosedRange<UInt32>,
 	let hexRange = AnyPattern("\(hexNumber)..\(hexNumber)") / hexNumber
 	let rangeAndProperty: AnyPattern = "\n\(hexRange, Skip()); \(Capture(name: "property", Skip())) "
 
-	return try! Parser(rangeAndProperty).matches(in: text).map { match in
+	return try! Parser(search: rangeAndProperty).matches(in: text).map { match in
 		let propertyName = text[match[one: "property"]!]
 		let oneOrTwoNumbers = match[multiple: "hexNumber"].map { UInt32(text[$0], radix: 16)! }
 		let range = oneOrTwoNumbers.first! ... oneOrTwoNumbers.last!

--- a/Tests/PatternsTests/GrammarTests.swift
+++ b/Tests/PatternsTests/GrammarTests.swift
@@ -27,12 +27,14 @@ class GrammarTests: XCTestCase {
 	func testDirectRecursion() throws {
 		let g1 = Grammar()
 		g1.a <- "a" / any • g1.a
-		assertParseAll(g1, input: " aa", count: 2)
+		let g1Parser = try Parser(g1)
+		assertParseAll(g1Parser, input: " aba", count: 2)
 
 		let g2 = Grammar()
 		g2.balancedParentheses <- "(" • (!OneOf("()") • any / g2.balancedParentheses)* • ")"
-		assertParseAll(g2, input: "( )", count: 1)
-		assertParseAll(g2, input: "((( )( )))", count: 1)
-		assertParseAll(g2, input: "(( )", count: 0)
+		let g2Parser = try Parser(g2)
+		assertParseAll(g2Parser, input: "( )", count: 1)
+		assertParseAll(g2Parser, input: "((( )( )))", count: 1)
+		assertParseAll(g2Parser, input: "(( )", count: 0)
 	}
 }

--- a/Tests/PerformanceTests/PerformanceTests.swift
+++ b/Tests/PerformanceTests/PerformanceTests.swift
@@ -28,61 +28,62 @@ class PerformanceTests: XCTestCase {
 	}
 
 	func testWordBoundary() throws {
-		let pattern = try Parser(Word.boundary)
+		let pattern = try Parser(search: Word.boundary)
 		try speedTest(pattern, textFraction: 16, hits: 79081)
 	}
 
 	func testWordBoundaryManyLanguages() throws {
-		let pattern = try Parser(Word.boundary)
+		let pattern = try Parser(search: Word.boundary)
 		try speedTest(pattern, testFile: "Multi-language-short.txt", hits: 49801)
 	}
 
 	func testUppercaseWord() throws {
-		let pattern = try Parser(Word.boundary • uppercase+ • Word.boundary)
+		let pattern = try Parser(search: Word.boundary • uppercase+ • Word.boundary)
 		try speedTest(pattern, textFraction: 8, hits: 887)
 	}
 
 	func testLine() throws {
-		let pattern = try Parser(Line.start • Capture(Skip()) • Line.end)
+		let pattern = try Parser(search: Line.start • Capture(Skip()) • Line.end)
 		try speedTest(pattern, textFraction: 6, hits: 2550)
 	}
 
 	func testNotNewLine() throws {
 		let any = OneOf(description: "any", contains: { _ in true })
 		let pattern = try Parser(
-			"," • Capture(Skip(any - newline)) • Line.end)
+			search: "," • Capture(Skip(any - newline)) • Line.end)
 		try speedTest(pattern, textFraction: 8, hits: 1413)
 	}
 
 	func testLiteralSearch() throws {
-		let pattern = try Parser(Literal("Prince"))
+		let pattern = try Parser(search: Literal("Prince"))
 		try speedTest(pattern, textFraction: 1, hits: 2168)
 	}
 
 	func testGrammarLiteralSearch() throws {
 		let g = Grammar()
 		g.a <- Capture("Prince") / any • g.a
-		try speedTest(Parser(g), textFraction: 13, hits: 260)
+		let pattern = try Parser(g)
+		try speedTest(pattern, textFraction: 13, hits: 260)
 	}
 
 	func testNonExistentLiteralSearch() throws {
-		let pattern = try Parser("\n" • Skip() • "DOESN'T EXIST")
+		let pattern = try Parser(search: "\n" • Skip() • "DOESN'T EXIST")
 		try speedTest(pattern, textFraction: 60, hits: 0)
 	}
 
 	func testOptionalStringFollowedByNonOptionalString() throws {
-		let pattern = try Parser(Literal("\"")¿ • "I")
+		let pattern = try Parser(search: Literal("\"")¿ • "I")
 		try speedTest(pattern, textFraction: 8, hits: 1136)
 	}
 
 	func testOneOrMore() throws {
-		let pattern = try Parser(Capture(ascii+))
+		let pattern = try Parser(search: Capture(ascii+))
 		try speedTest(pattern, textFraction: 8, hits: 6041)
 	}
 
 	func testSkipping1() throws {
 		// [ word.boundary ] * " " * ":" * " " * " " * " " * "{" * Line.end
-		let pattern = try Parser(Skip() • "." • Skip() • " " • Skip() • " ")
+		let pattern = try Parser(search: Skip() • "." • Skip() • " " • Skip() • " ")
 		try speedTest(pattern, textFraction: 6, hits: 4779)
 	}
 
@@ -97,7 +98,7 @@ class PerformanceTests: XCTestCase {
 
 		let digits = digit+
 		let pattern = try Parser(
-			OneOf("+-")¿
+			search: OneOf("+-")¿
 				• (digits • ("." • digits)¿)
 				/
 				("." • digits)
@@ -106,7 +107,7 @@ class PerformanceTests: XCTestCase {
 	}
 
 	func testContainsClosure() throws {
-		let pattern = try Parser(Word.boundary • (alphanumeric / symbol))
+		let pattern = try Parser(search: Word.boundary • (alphanumeric / symbol))
 		try speedTest(pattern, textFraction: 16, hits: 35643)
 	}
 }


### PR DESCRIPTION
Replace Parser.Match.fullRange with .endIndex.