### PR TITLE
Add grammar test testArithmetic.

### DIFF
--- a/Sources/Patterns/Parser.swift
+++ b/Sources/Patterns/Parser.swift
@@ -61,7 +61,7 @@ public struct Parser<Input: BidirectionalCollection> where Input.Element: Equata
 
 		public func description(using input: Input) -> String {
 			"""
-			endIndex: "\(input[endIndex])"
+			endIndex: "\(endIndex == input.endIndex ? "EOF" : String(describing: input[endIndex]))"
 			\(captures.map { "\($0.name.map { $0 + ":" } ?? "") \(input[$0.range])" }.joined(separator: "\n"))
 
 			"""

--- a/Tests/PatternsTests/GrammarTests.swift
+++ b/Tests/PatternsTests/GrammarTests.swift
@@ -39,4 +39,19 @@ class GrammarTests: XCTestCase {
 		assertParseAll(g2Parser, input: "((( )( )))", count: 1)
 		assertParseAll(g2Parser, input: "(( )", count: 0)
 	}
+
+	func testArithmetic() throws {
+		let g = Grammar { g in
+			g.all <- g.expr • !any
+			g.expr <- g.sum
+			g.sum <- g.product • (("+" / "-") • g.product)*
+			g.product <- g.power • (("*" / "/") • g.power)*
+			g.power <- g.value • ("^" • g.power)¿
+			g.value <- digit+ / "(" • g.expr • ")"
+		}
+
+		let p = try Parser(g)
+		assertParseMarkers(p, input: "1+2-3*(4+3)|")
+		assertParseAll(p, input: "1+2(", count: 0)
+	}
 }


### PR DESCRIPTION
Avoid crash in Parser.Match.description if the end index of the match equals the end index of the input.