### PR TITLE
Fix bug where not all .skip were replaced.

### DIFF
--- a/Sources/Patterns/Operations on Patterns/Skip.swift
+++ b/Sources/Patterns/Operations on Patterns/Skip.swift
@@ -26,13 +26,16 @@ import SE0270_RangeSet
 extension MutableCollection where Self: RandomAccessCollection, Self: RangeReplaceableCollection, Index == Int {
 	@usableFromInline
 	mutating func replaceSkips<Input>() where Element == Instruction<Input> {
-		for i in self.indices {
+		// `setupSkip(at: i)` adds 1 new instruction somewhere after `ì`, so we cant loop over self.indices directly
+		var i = self.startIndex
+		repeat {
 			switch self[i] {
 			case .skip:
 				self.setupSkip(at: i)
 			default: break
 			}
-		}
+			self.formIndex(after: &i)
+		} while i < self.endIndex
 	}
 
 	@usableFromInline

--- a/Tests/PatternsTests/ConcatenationTests.swift
+++ b/Tests/PatternsTests/ConcatenationTests.swift
@@ -166,6 +166,19 @@ class ConcatenationTests: XCTestCase {
 		assertCaptures(rangeAndProperty, input: text, result: [["0005", "0010", "Common"], ["002F", "Common"]])
 	}
 
+	func testAnyPattern() throws {
+		let text = """
+		 : Test Case '-[PerformanceTests.PerformanceTests testAnyNumeral]' measured [CPU Instructions Retired, kI] average: 6071231.970, relative standard deviation: 0.300%, values: [6125777.558000, 6066280.613000, 6064787.491000, 6063915.538000, 6066853.091000, 6063079.064000, 6068140.744000, 6064901.279000, 6064321.893000, 6064262.431000], performanceMetricID:com.apple.dt.XCTMetric_CPU.instructions_retired, baselineName: "", baselineAverage: , maxPercentRegression: 10.000%, maxPercentRelativeStandardDeviation: 10.000%, maxRegression: 0.000, maxStandardDeviation: 0.000
+
+		"""
+		let skip = Skip()
+		let measurementPattern = AnyPattern("""
+		: Test Case '-[\(skip).\(Capture(name: "name", skip))]' measured [\(Capture(name: "measurementName", skip)), \(Capture(name: "measurementUnit", skip))] average: \(Capture(name: "average", skip)), relative standard deviation: \(Capture(name: "standardDeviation", skip))%\(skip), performanceMetricID:\(Capture(name: "measurementID", skip)),\(skip)
+
+		""")
+		assertParseAll(measurementPattern, input: text, count: 1)
+	}
+
 	func testMatchDecoding() throws {
 		struct Property: Decodable, Equatable {
 			let codePoint: [Int]


### PR DESCRIPTION
`setupSkip(at: i)` adds 1 new instruction somewhere after `ì`, so we cant loop over self.indices directly.